### PR TITLE
Upgrade parent to maven-shared-components 49

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -18,14 +17,13 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.apache.maven.shared</groupId>
     <artifactId>maven-shared-components</artifactId>
-    <version>34</version>
+    <version>49</version>
     <relativePath />
   </parent>
 
@@ -51,8 +49,8 @@ under the License.
   <scm>
     <connection>scm:git:https://gitbox.apache.org/repos/asf/maven-reporting-api.git</connection>
     <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/maven-reporting-api.git</developerConnection>
-    <url>https://github.com/apache/maven-reporting-api/tree/${project.scm.tag}</url>
     <tag>HEAD</tag>
+    <url>https://github.com/apache/maven-reporting-api/tree/${project.scm.tag}</url>
   </scm>
   <issueManagement>
     <system>jira</system>
@@ -68,11 +66,24 @@ under the License.
       <url>scm:svn:https://svn.apache.org/repos/asf/maven/website/components/${maven.site.path}</url>
     </site>
   </distributionManagement>
-  
+
   <properties>
     <javaVersion>7</javaVersion>
     <project.build.outputTimestamp>2022-07-29T20:28:12Z</project.build.outputTimestamp>
   </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.doxia</groupId>
+      <artifactId>doxia-sink-api</artifactId>
+      <version>1.11.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-container-default</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
 
   <build>
     <pluginManagement>
@@ -90,17 +101,4 @@ under the License.
       </plugins>
     </pluginManagement>
   </build>
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.maven.doxia</groupId>
-      <artifactId>doxia-sink-api</artifactId>
-      <version>1.11.1</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>plexus-container-default</artifactId>
-          <groupId>org.codehaus.plexus</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-  </dependencies>
 </project>

--- a/src/main/java/org/apache/maven/reporting/MavenMultiPageReport.java
+++ b/src/main/java/org/apache/maven/reporting/MavenMultiPageReport.java
@@ -1,5 +1,3 @@
-package org.apache.maven.reporting;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -9,7 +7,7 @@ package org.apache.maven.reporting;
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -18,11 +16,12 @@ package org.apache.maven.reporting;
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.maven.reporting;
+
+import java.util.Locale;
 
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.SinkFactory;
-
-import java.util.Locale;
 
 /**
  * Interface created separately for backwards compatibility. This method
@@ -33,9 +32,7 @@ import java.util.Locale;
  * @see MavenReport#generate(org.codehaus.doxia.sink.Sink, Locale)
  * @since 3.0 (copied in maven-site-plugin 2.0-beta-6)
  */
-public interface MavenMultiPageReport
-    extends MavenReport
-{
+public interface MavenMultiPageReport extends MavenReport {
     /**
      * Generate multi page report.
      *
@@ -43,6 +40,5 @@ public interface MavenMultiPageReport
      * @param locale The locale to use.
      * @throws MavenReportException if an error occurs.
      */
-    void generate( Sink sink, SinkFactory sinkFactory, Locale locale )
-        throws MavenReportException;
+    void generate(Sink sink, SinkFactory sinkFactory, Locale locale) throws MavenReportException;
 }

--- a/src/main/java/org/apache/maven/reporting/MavenReport.java
+++ b/src/main/java/org/apache/maven/reporting/MavenReport.java
@@ -1,5 +1,3 @@
-package org.apache.maven.reporting;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -9,7 +7,7 @@ package org.apache.maven.reporting;
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -18,11 +16,12 @@ package org.apache.maven.reporting;
  * specific language governing permissions and limitations
  * under the License.
  */
-
-import org.codehaus.doxia.sink.Sink;
+package org.apache.maven.reporting;
 
 import java.io.File;
 import java.util.Locale;
+
+import org.codehaus.doxia.sink.Sink;
 
 /**
  * The basis for a Maven report.
@@ -32,8 +31,7 @@ import java.util.Locale;
  * @author <a href="mailto:vincent.siveton@gmail.com">Vincent Siveton</a>
  * @since 2.0
  */
-public interface MavenReport
-{
+public interface MavenReport {
     /** Plexus lookup name */
     String ROLE = MavenReport.class.getName();
 
@@ -52,8 +50,7 @@ public interface MavenReport
      * @param locale the wanted locale to generate the report, could be null.
      * @throws MavenReportException if any
      */
-    void generate( Sink sink, Locale locale )
-        throws MavenReportException;
+    void generate(Sink sink, Locale locale) throws MavenReportException;
 
     /**
      * Get the base name used to create report's output file(s).
@@ -76,7 +73,7 @@ public interface MavenReport
      * @param locale the wanted locale to return the report's name, could be null.
      * @return the name of this report.
      */
-    String getName( Locale locale );
+    String getName(Locale locale);
 
     /**
      * Get the localized report description.
@@ -84,14 +81,14 @@ public interface MavenReport
      * @param locale the wanted locale to return the report's description, could be null.
      * @return the description of this report.
      */
-    String getDescription( Locale locale );
+    String getDescription(Locale locale);
 
     /**
      * Set a new output directory. Useful for staging.
      *
      * @param outputDirectory the new output directory
      */
-    void setReportOutputDirectory( File outputDirectory );
+    void setReportOutputDirectory(File outputDirectory);
 
     /**
      * @return the current report output directory.

--- a/src/main/java/org/apache/maven/reporting/MavenReportException.java
+++ b/src/main/java/org/apache/maven/reporting/MavenReportException.java
@@ -1,5 +1,3 @@
-package org.apache.maven.reporting;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -9,7 +7,7 @@ package org.apache.maven.reporting;
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -18,6 +16,7 @@ package org.apache.maven.reporting;
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.maven.reporting;
 
 /**
  * An exception occurring during the execution of a Maven report.
@@ -26,9 +25,7 @@ package org.apache.maven.reporting;
  * @author <a href="evenisse@apache.org">Emmanuel Venisse</a>
  * @since 2.0
  */
-public class MavenReportException
-    extends Exception
-{
+public class MavenReportException extends Exception {
     /** The serialVersionUID **/
     public static final long serialVersionUID = -6200353563231163785L;
 
@@ -37,9 +34,8 @@ public class MavenReportException
      *
      * @param msg the exception message.
      */
-    public MavenReportException( String msg )
-    {
-        super( msg );
+    public MavenReportException(String msg) {
+        super(msg);
     }
 
     /**
@@ -48,8 +44,7 @@ public class MavenReportException
      * @param msg the exception message.
      * @param cause the cause.
      */
-    public MavenReportException( String msg, Exception cause )
-    {
-        super( msg, cause );
+    public MavenReportException(String msg, Exception cause) {
+        super(msg, cause);
     }
 }

--- a/src/main/java/org/apache/maven/reporting/MavenReportRenderer.java
+++ b/src/main/java/org/apache/maven/reporting/MavenReportRenderer.java
@@ -1,5 +1,3 @@
-package org.apache.maven.reporting;
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -9,7 +7,7 @@ package org.apache.maven.reporting;
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -18,6 +16,7 @@ package org.apache.maven.reporting;
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.maven.reporting;
 
 /**
  * Basis for rendering report.
@@ -29,8 +28,7 @@ package org.apache.maven.reporting;
  * that could take a velocity template and pipe that through Doxia rather than coding
  * them up like this.
  */
-public interface MavenReportRenderer
-{
+public interface MavenReportRenderer {
     /**
      * @return the wanted report's title.
      */


### PR DESCRIPTION
This branch's Jenkins build is currently failing:

```
[ERROR] Failed to execute goal org.apache.rat:apache-rat-plugin:0.13:check (rat-check)
        on project maven-reporting-api: Too many files with unapproved license: 1
```

The cause is external to the repository. The ASF shared Jenkins library now provisions the Maven wrapper into the workspace before building (apache/maven-jenkins-lib#22), which writes `.mvn/wrapper/maven-wrapper.properties`. That file has no licence header, and the apache-rat **0.13** pinned by parent 34 counts it as unapproved.

Verified locally, generating the wrapper exactly as CI does and running the check both ways:

| parent | rat | result |
|---|---|---|
| 34 (current) | 0.13 | `Unapproved: 1, unknown: 1` — `rat.txt` names `.mvn/wrapper/maven-wrapper.properties` |
| 49 (this PR) | 0.16.1 | `Unapproved: 0, unknown: 0, approved: 15` |

`mvnw` and `mvnw.cmd` are fine either way — the wrapper ships those with ASF headers; only the `.properties` file lacks one.

The source changes are spotless from the new parent, applied rather than hand-edited: the licence header moves above the `package` statement, imports are reordered, and the modern Maven brace/spacing style is applied. I removed the old post-package header blocks so the header is not duplicated — spotless adds the new one at the top but does not remove the old one. There are no code changes.

`spotless:check` and `apache-rat:check` both pass locally. I could not run the full build here: the branch targets Java 7 and my local JDK is too new (`release version 7 not supported`); CI builds it on JDK 8/11/17.

`maven-reporting-impl-3.x` is on parent 34 as well and will likely need the same treatment, though its build currently fails earlier on a missing `doxia-sink-api:1.12.0-SNAPSHOT`. Context in apache/maven#12676.