### PR TITLE
Let Dependabot update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,8 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
Dependabot watches this repository's Maven dependencies but not its GitHub Actions, so nothing has ever proposed a workflow update here. This adds the `github-actions` ecosystem, matching the 81 other active Maven repositories that already have it.

The gap is not theoretical. This repository still references `apache/maven-gh-actions-shared/.github/workflows/*.yml@v4`, while the rest of the org has moved to `@v5`. It was left behind precisely because no bump PR was ever opened for it — see apache/maven-gh-actions-shared#247, where the migration is tracked and the "Bump apache/maven-gh-actions-shared" PR queue is now empty everywhere else.

Staying on `v4` also means still hitting apache/maven-gh-actions-shared#284, where a `pull_request` from a non-fork branch fails the whole run with `fromJSON: empty input` before any job starts.

Formatting follows this file's existing style rather than a single house style — indentation and quoting match the `maven` entry already present.
