### PR TITLE
Drop branch protection for the retired maven-reporting-api-3.x line

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,7 +25,6 @@ github:
     - maven
   protected_branches:
     master: { }
-    maven-reporting-api-3.x: { }
   pull_requests:
     del_branch_on_merge: true
   enabled_merge_buttons:


### PR DESCRIPTION
Prerequisite for retiring `maven-reporting-api-3.x`; see apache/maven-doxia#1079 for the containment evidence
and what the retirement costs. Nothing else in the file changes.

*This change was created with AI assistance.*
